### PR TITLE
fix: rethrow error on catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ async function ocrSpace(input, options = {}) {
     return data;
   } catch (error) {
     console.error(error);
+    throw error;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ocr-space-api-wrapper",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ocr-space-api-wrapper",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "license": "MIT",
       "dependencies": {
         "axios": "~0.30.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ocr-space-api-wrapper",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Node.js wrapper for ocr.space APIs.",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,15 +2,11 @@ const assert = require('assert');
 const { ocrSpace } = require('../index');
 
 describe('Tests for OCR Space API Wrapper', () => {
-  it('should return undefined if input is wrong', async () => {
-    const res1 = await ocrSpace();
-    assert.strictEqual(res1, undefined);
-    const res2 = await ocrSpace('');
-    assert.strictEqual(res2, undefined);
-    const res3 = await ocrSpace(1);
-    assert.strictEqual(res3, undefined);
-    const res4 = await ocrSpace(true);
-    assert.strictEqual(res4, undefined);
+  it('should throw if input is wrong', async () => {
+    await assert.rejects(() => ocrSpace());
+    await assert.rejects(() => ocrSpace(''));
+    await assert.rejects(() => ocrSpace(1));
+    await assert.rejects(() => ocrSpace(true));
   });
   it('should return results with a URL input', async () => {
     const res1 = await ocrSpace('http://dl.a9t9.com/ocrbenchmark/eng.png');
@@ -76,12 +72,11 @@ describe('Tests for OCR Space API Wrapper', () => {
     assert.notStrictEqual(res1.SearchablePDFURL, 'Searchable PDF not generated as it was not requested.');
     assert.match(res1.SearchablePDFURL, /https?:\/\/.*\.pdf/);
   });
-  it('should abort the request', async () => {
+  it('should throw if the request is aborted', async () => {
     const controller = new AbortController();
     const { signal } = controller;
     const promise = ocrSpace('./test/eng.png', { signal });
     controller.abort();
-    const res1 = await promise;
-    assert.strictEqual(res1, undefined);
+    await assert.rejects(promise);
   });
 });


### PR DESCRIPTION
throw error was missing on catch, just a console log was added.

Let me know what you think, I slightly changed the test for abort @romant094 because when the request is aborted the promise is rejected.